### PR TITLE
Update dependencies for ansi-regex CVE-2021-3807

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .log
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "chalk": "^2.4.2",
     "error-stack-parser": "^2.0.2",
-    "string-width": "^2.0.0",
-    "strip-ansi": "^5"
+    "string-width": "^4.2.3",
+    "strip-ansi": "^6.0.1"
   }
 }


### PR DESCRIPTION
This updates string-width and strip-ansi to versions that
require ansi-regex 5.0.1 for CVE-2021-3807 [1][2].

[1] https://nvd.nist.gov/vuln/detail/CVE-2021-3807
[2] https://github.com/advisories/GHSA-93q8-gq69-wqmw

Closes #5